### PR TITLE
chore: Avoid mutating input array in sorting methods

### DIFF
--- a/src/sortUtils.ts
+++ b/src/sortUtils.ts
@@ -7,7 +7,7 @@ export const sortArray = <T>(array: T[], key: keyof T, order: "asc" | "desc" = "
 };
 
 export const sortByMultipleKeys = <T>(array: T[], keys: { key: keyof T; order: "asc" | "desc" }[]): T[] => {
-  return array.sort((a, b) => {
+  return [...array].sort((a, b) => {
     for (const { key, order } of keys) {
       if (a[key] < b[key]) return order === "asc" ? -1 : 1;
       if (a[key] > b[key]) return order === "asc" ? 1 : -1;

--- a/src/sortUtils.ts
+++ b/src/sortUtils.ts
@@ -1,5 +1,5 @@
 export const sortArray = <T>(array: T[], key: keyof T, order: "asc" | "desc" = "asc"): T[] => {
-  return array.sort((a, b) => {
+  return [...array].sort((a, b) => {
     if (a[key] < b[key]) return order === "asc" ? -1 : 1;
     if (a[key] > b[key]) return order === "asc" ? 1 : -1;
     return 0;

--- a/src/sortUtils.ts
+++ b/src/sortUtils.ts
@@ -17,7 +17,7 @@ export const sortByMultipleKeys = <T>(array: T[], keys: { key: keyof T; order: "
 };
 
 export const sortByCustomComparator = <T>(array: T[], comparator: (a: T, b: T) => number): T[] => {
-  return array.sort(comparator);
+  return [...array].sort(comparator);
 };
 
 // export const groupBy = <T>(array: T[], key: keyof T): Record<string, T[]> => {

--- a/test/sort.test.ts
+++ b/test/sort.test.ts
@@ -50,6 +50,19 @@ describe("SortUtils", () => {
     expect(sorted[0].age).toBe(30);
   });
 
+  test("sortArray should not mutate input", () => {
+    const array = [
+      { name: "Bob", age: 25 },
+      { name: "Alice", age: 30 },
+    ];
+
+    const original = [...array];
+
+    sortArray(array, "age", "desc");
+
+    expect(array).toEqual(original);
+  });
+
   test("sorts array of objects by multiple keys", () => {
     const array = [
       { name: "Bob", age: 25 },

--- a/test/sort.test.ts
+++ b/test/sort.test.ts
@@ -92,6 +92,19 @@ describe("SortUtils", () => {
     ]);
   });
 
+  test("sortByCustomComparator should not mutate input", () => {
+    const array = [
+      { name: "Alice", age: 30 },
+      { name: "Bob", age: 25 },
+    ];
+
+    const original = [...array];
+
+    sortByCustomComparator(array, (a, b) => a.age - b.age);
+
+    expect(array).toEqual(original);
+  });
+
   test("finds minimum element by key", () => {
     const array = [
       { name: "Bob", age: 25 },

--- a/test/sort.test.ts
+++ b/test/sort.test.ts
@@ -80,6 +80,23 @@ describe("SortUtils", () => {
     ]);
   });
 
+  test("sortByMultipleKeys should not mutate input", () => {
+    const array = [
+      { name: "Bob", age: 25 },
+      { name: "Alice", age: 30 },
+      { name: "Bob", age: 20 },
+    ];
+
+    const original = [...array];
+
+    sortByMultipleKeys(array, [
+      { key: "name", order: "asc" },
+      { key: "age", order: "asc" },
+    ]);
+
+    expect(array).toEqual(original);
+  });
+
   test("sorts array of objects using a custom comparator", () => {
     const array = [
       { name: "Bob", age: 25 },


### PR DESCRIPTION
Hi @nachorsanz, what a great project!

While doing some testing I detected that some of the sorting utilities were mutating the original arrays.

In my opinion the best way to go is to avoid this, as it might cause unexpected behaviour in some use cases like this one:

```js
const original = [
  { value: 1 },
  { value: 3 },
  { value: 2 }
]

const sorted = sortArray(original, "value", "asc")

console.log(original) // The original has also been sorted
```

In this PR I have modified `sortArray`, `sortByMultipleKeys` and `sortByCustomComparator` to avoid this behaviour.

I also added tests to ensure the original is not changed.

Other options would be:
- Document this behaviour so the users know that the input will be changed
- Use `toSorted` instead of using the spread operator (this depends on the ESM version you are willing to support)

> [!WARNING]
> This is tecnically a breaking change, but I used `fix` as it can also be seen as a bug in the implementation.


Hope this helps :)